### PR TITLE
Clean up, and feature addition to loop.py

### DIFF
--- a/loop.py
+++ b/loop.py
@@ -113,14 +113,12 @@ class Loop(object):
                 if len(cols) > 1:
                     self.args_ref = ' '.join(cols[1:]).split()
                 self.ref_data = calculate.main(self.args_ref)
-                self.ref_data = np.array(sorted(self.ref_data, key=datatypes.datum_sort_key))
             if cols[0] == 'CDAT':
                 logger.log(
                     20, '~~ CALCULATING FF DATA ~~'.rjust(79, '~'))
                 if len(cols) > 1:
                     self.args_ff = ' '.join(cols[1:]).split()
                 self.ff.data = calculate.main(self.args_ff)
-                self.ff.data = np.array(sorted(self.ff.data, key=datatypes.datum_sort_key))
             if cols[0] == 'COMP':
                 self.ff.score = compare.compare_data(
                     self.ref_data, self.ff.data)
@@ -129,6 +127,10 @@ class Loop(object):
                         self.ref_data,
                         self.ff.data,
                         os.path.join(self.direc, cols[cols.index('-o') + 1]))
+                else:
+                    compare.pretty_data_comp(
+                        self.ref_data,
+                        self.ff.data)
             if cols[0] == 'GRAD':
                 grad = gradient.Gradient(
                     direc=self.direc,
@@ -143,6 +145,9 @@ class Loop(object):
                     ff_lines=self.ff.lines,
                     args_ff=self.args_ff)
                 self.ff = simp.run(r_data=self.ref_data)
+            if cols[0] == 'WGHT':
+                data_type = cols[1]
+                co.WEIGHTS[data_type] = float(cols[2])
         
 def read_loop_input(filename):
     with open(filename, 'r') as f:

--- a/loop.py
+++ b/loop.py
@@ -127,7 +127,7 @@ class Loop(object):
                         self.ref_data,
                         self.ff.data,
                         os.path.join(self.direc, cols[cols.index('-o') + 1]))
-                else:
+                if '-p' in cols:
                     compare.pretty_data_comp(
                         self.ref_data,
                         self.ff.data)


### PR DESCRIPTION
Sorting was still present in RDAT and CDAT, and so those lines of code were removed.

Added section with COMP command now allows you to just print out results on the front end if you do not put any output option.

Added a new command for a loop input file called WGHT or weight. In order for the code to pick up this new weight, the command should be entered in before the RDAT or CDAT. This allows as user to adjust the default weights of a data type without having to edit the constants.py textfile. There must be a 'WGHT' line for every datatype that a user wants to adjust. they must have a  An example below will change the weight of all 'eao' and 'ea' datatypes to 100 and 50, respectively.

WGHT eao 100
WGHT ea 50