### PR TITLE
Datum.type for Gaussian energies were all the same

### DIFF
--- a/calculate.py
+++ b/calculate.py
@@ -653,7 +653,7 @@ def collect_data(coms, inps, direc='.', sub_names=['OPT']):
                 temp.append(datatypes.Datum(
                         val=e,
                         com='gea',
-                        typ='e',
+                        typ='ea',
                         src_1=filename,
                         idx_1=idx_1 + 1,
                         idx_2=i + 1))
@@ -737,7 +737,7 @@ def collect_data(coms, inps, direc='.', sub_names=['OPT']):
                 temp.append(datatypes.Datum(
                         val=e,
                         com='geo',
-                        typ='e',
+                        typ='eo',
                         src_1=filename,
                         idx_1=idx_1 + 1,
                         idx_2=i + 1))
@@ -812,7 +812,7 @@ def collect_data(coms, inps, direc='.', sub_names=['OPT']):
                 temp.append(datatypes.Datum(
                         val=e,
                         com='geao',
-                        typ='e',
+                        typ='eao',
                         src_1=filename,
                         idx_1=idx_1 + 1,
                         idx_2=i + 1))


### PR DESCRIPTION
Only the Gaussian energies had every Datum.typ = 'e' (Jaguar and
MacroModel were both set properly). This has been corrected.