### PR TITLE
Compatibility for Python 2 and 3

### DIFF
--- a/q2mm/calculate.py
+++ b/q2mm/calculate.py
@@ -81,8 +81,14 @@ def main(args):
            it's a string, it will be converted into a list of strings.
     """
     # Should be a list of strings for use by argparse. Ensure that's the case.
-    if isinstance(args, basestring):
-        args.split()
+    # basestring is deprecated in python3, str is probably safe to use in both
+    # but should be tested, for now sys.version_info switch can handle it
+    if (sys.version_info > (3, 0)):
+        if isinstance(args, str):
+            args = args.split()
+    else:
+        if isinstance(args, basestring):
+            args = args.split()
     parser = return_calculate_parser()
     opts = parser.parse_args(args)
     # This makes a dictionary that only contains the arguments related to

--- a/q2mm/calculate.py
+++ b/q2mm/calculate.py
@@ -193,7 +193,11 @@ def main(args):
     if opts.norun or opts.fake:
         logger.log(15, "  -- Skipping backend calculations.")
     else:
-        for filename, some_class in inps.iteritems():
+        if (sys.version_info > (3, 0)):
+            inps_iter = iter(inps.items())
+        else:
+            inps_iter = inps.iteritems()
+        for filename, some_class in inps_iter:
             logger.log(1, '>>> filename: {}'.format(filename))
             logger.log(1, '>>> some_class: {}'.format(some_class))
             # Works if some class is None too.

--- a/q2mm/calculate.py
+++ b/q2mm/calculate.py
@@ -25,7 +25,10 @@ import sys
 # chain.from_iterable flattens a list of lists similar to:
 #   [child for parent in grandparent for child in parent]
 # However, I think chain.from_iterable works on any number of nested lists.
-from itertools import chain, izip
+if (sys.version_info > (3, 0)):
+    from itertools import chain
+else:
+    from itertools import chain, izip
 from textwrap import TextWrapper
 
 import constants as co
@@ -194,11 +197,11 @@ def main(args):
         sub_names = opts.subnames
     if opts.fake:
         data = collect_data_fake(
-            commands, inps, direc=opts.directory, invert=opts.invert, 
+            commands, inps, direc=opts.directory, invert=opts.invert,
             sub_names=sub_names)
     else:
         data = collect_data(
-            commands, inps, direc=opts.directory, invert=opts.invert, 
+            commands, inps, direc=opts.directory, invert=opts.invert,
             sub_names=sub_names)
     # Adds weights to the data points in the data list.
     if opts.weight:
@@ -578,7 +581,7 @@ def collect_data(coms, inps, direc='.', sub_names=['OPT'], invert=None):
         # Unlike most datatypes, these Datum only get the attributes _lbl,
         # val and wht. This is to ensure that making and working with these
         # reference text files isn't too cumbersome.
-        data.extend(collect_reference(os.path.join(direc, filename)))    
+        data.extend(collect_reference(os.path.join(direc, filename)))
     # MACROMODEL MM3* CURRENT PARAMETER VALUES
     filenames = chain.from_iterable(coms['mp'])
     for comma_filenames in filenames:
@@ -1076,7 +1079,7 @@ def collect_data(coms, inps, direc='.', sub_names=['OPT'], invert=None):
         temp = []
         for filename in filenames:
             temp.append(collect_structural_data_from_tinker_log(
-                filename, inps, outs, direc, 'tea', 'pre', 'ea', idx_1 = idx_1)) 
+                filename, inps, outs, direc, 'tea', 'pre', 'ea', idx_1 = idx_1))
         avg = sum([x.val for x in temp]) / len(temp)
         for datum in temp:
             datum.val -= avg
@@ -1087,7 +1090,7 @@ def collect_data(coms, inps, direc='.', sub_names=['OPT'], invert=None):
         temp = []
         for filename in filenames:
             temp.append(collect_structural_data_from_tinker_log(
-                filename, inps, outs, direc, 'teo', 'opt', 'eo', idx_1 = idx_1)) 
+                filename, inps, outs, direc, 'teo', 'opt', 'eo', idx_1 = idx_1))
         zero = min([x.val for x in temp])
         for datum in temp:
             datum.val -= zero
@@ -1098,7 +1101,7 @@ def collect_data(coms, inps, direc='.', sub_names=['OPT'], invert=None):
         temp = []
         for filename in filenames:
             temp.append(collect_structural_data_from_tinker_log(
-                filename, inps, outs, direc, 'teao', 'opt', 'eao', idx_1 = idx_1)) 
+                filename, inps, outs, direc, 'teao', 'opt', 'eao', idx_1 = idx_1))
         avg = sum([x.val for x in temp]) / len(temp)
         for datum in temp:
             datum.val -= avg
@@ -1117,15 +1120,26 @@ def collect_data(coms, inps, direc='.', sub_names=['OPT'], invert=None):
         # I'm not even sure if we can use dummy atoms in TINKER.
         low_tri_idx = np.tril_indices_from(hess)
         low_tri = hess[low_tri_idx]
-        data.extend([datatypes.Datum(
-            val=e,
-            com='th',
-            typ='h',
-            src_1=hes.filename,
-            idx_1=x + 1,
-            idx_2=y + 1)
-                for e, x, y in izip(
-                    low_tri, low_tri_idx[0], low_tri_idx[1])])
+        if (sys.version_info > (3, 0)):
+            data.extend([datatypes.Datum(
+                val=e,
+                com='th',
+                typ='h',
+                src_1=hes.filename,
+                idx_1=x + 1,
+                idx_2=y + 1)
+                    for e, x, y in zip(
+                        low_tri, low_tri_idx[0], low_tri_idx[1])])
+        else:
+            data.extend([datatypes.Datum(
+                val=e,
+                com='th',
+                typ='h',
+                src_1=hes.filename,
+                idx_1=x + 1,
+                idx_2=y + 1)
+                    for e, x, y in izip(
+                        low_tri, low_tri_idx[0], low_tri_idx[1])])
     # TINKER EIGENMATRIX USING GAUSSIAN EIGENVECTORS
     filenames = chain.from_iterable(coms['tgeig'])
     for comma_filenames in filenames:
@@ -1151,16 +1165,28 @@ def collect_data(coms, inps, direc='.', sub_names=['OPT'], invert=None):
             raise
         low_tri_idx = np.tril_indices_from(eigenmatrix)
         low_tri = eigenmatrix[low_tri_idx]
-        data.extend([datatypes.Datum(
-            val=e,
-            com='tgeig',
-            typ='eig',
-            src_1=name_xyz,
-            src_2=name_gau_log,
-            idx_1=x + 1,
-            idx_2=y + 1)
-                for e, x, y in izip(
-                    low_tri, low_tri_idx[0], low_tri_idx[1])])
+        if (sys.version_info > (3, 0)):
+            data.extend([datatypes.Datum(
+                val=e,
+                com='tgeig',
+                typ='eig',
+                src_1=name_xyz,
+                src_2=name_gau_log,
+                idx_1=x + 1,
+                idx_2=y + 1)
+                    for e, x, y in zip(
+                        low_tri, low_tri_idx[0], low_tri_idx[1])])
+        else:
+            data.extend([datatypes.Datum(
+                val=e,
+                com='tgeig',
+                typ='eig',
+                src_1=name_xyz,
+                src_2=name_gau_log,
+                idx_1=x + 1,
+                idx_2=y + 1)
+                    for e, x, y in izip(
+                        low_tri, low_tri_idx[0], low_tri_idx[1])])
     # MACROMODEL BONDS
     filenames = chain.from_iterable(coms['mb'])
     for filename in filenames:
@@ -1360,15 +1386,26 @@ def collect_data(coms, inps, direc='.', sub_names=['OPT'], invert=None):
         datatypes.replace_minimum(hess, value=invert)
         low_tri_idx = np.tril_indices_from(hess)
         low_tri = hess[low_tri_idx]
-        data.extend([datatypes.Datum(
-                    val=e,
-                    com='jh',
-                    typ='h',
-                    src_1=jin.filename,
-                    idx_1=x + 1,
-                    idx_2=y + 1)
-                     for e, x, y in izip(
-                    low_tri, low_tri_idx[0], low_tri_idx[1])])
+        if (sys.version_info > (3, 0)):
+            data.extend([datatypes.Datum(
+                        val=e,
+                        com='jh',
+                        typ='h',
+                        src_1=jin.filename,
+                        idx_1=x + 1,
+                        idx_2=y + 1)
+                         for e, x, y in zip(
+                        low_tri, low_tri_idx[0], low_tri_idx[1])])
+        else:
+            data.extend([datatypes.Datum(
+                        val=e,
+                        com='jh',
+                        typ='h',
+                        src_1=jin.filename,
+                        idx_1=x + 1,
+                        idx_2=y + 1)
+                         for e, x, y in izip(
+                        low_tri, low_tri_idx[0], low_tri_idx[1])])
     # GAUSSIAN HESSIAN
     filenames = chain.from_iterable(coms['gh'])
     for filename in filenames:
@@ -1389,15 +1426,26 @@ def collect_data(coms, inps, direc='.', sub_names=['OPT'], invert=None):
         # WARNING: This option may need to be mass weighted!
         low_tri_idx = np.tril_indices_from(hess)
         low_tri = hess[low_tri_idx]
-        data.extend([datatypes.Datum(
-                    val=e,
-                    com='gh',
-                    typ='h',
-                    src_1=log.filename,
-                    idx_1=x + 1,
-                    idx_2=y + 1)
-                     for e, x, y in izip(
-                    low_tri, low_tri_idx[0], low_tri_idx[1])])
+        if (sys.version_info > (3, 0)):
+            data.extend([datatypes.Datum(
+                        val=e,
+                        com='gh',
+                        typ='h',
+                        src_1=log.filename,
+                        idx_1=x + 1,
+                        idx_2=y + 1)
+                         for e, x, y in zip(
+                        low_tri, low_tri_idx[0], low_tri_idx[1])])
+        else:
+            data.extend([datatypes.Datum(
+                        val=e,
+                        com='gh',
+                        typ='h',
+                        src_1=log.filename,
+                        idx_1=x + 1,
+                        idx_2=y + 1)
+                         for e, x, y in izip(
+                        low_tri, low_tri_idx[0], low_tri_idx[1])])
     # MACROMODEL HESSIAN
     filenames = chain.from_iterable(coms['mh'])
     for filename in filenames:
@@ -1413,15 +1461,26 @@ def collect_data(coms, inps, direc='.', sub_names=['OPT'], invert=None):
         hess = datatypes.check_mm_dummy(hess, hess_dummies)
         low_tri_idx = np.tril_indices_from(hess)
         low_tri = hess[low_tri_idx]
-        data.extend([datatypes.Datum(
-                    val=e,
-                    com='mh',
-                    typ='h',
-                    src_1=mae.filename,
-                    idx_1=x + 1,
-                    idx_2=y + 1)
-                     for e, x, y in izip(
-                    low_tri, low_tri_idx[0], low_tri_idx[1])])
+        if (sys.version_info > (3, 0)):
+            data.extend([datatypes.Datum(
+                        val=e,
+                        com='mh',
+                        typ='h',
+                        src_1=mae.filename,
+                        idx_1=x + 1,
+                        idx_2=y + 1)
+                         for e, x, y in zip(
+                        low_tri, low_tri_idx[0], low_tri_idx[1])])
+        else:
+            data.extend([datatypes.Datum(
+                        val=e,
+                        com='mh',
+                        typ='h',
+                        src_1=mae.filename,
+                        idx_1=x + 1,
+                        idx_2=y + 1)
+                         for e, x, y in izip(
+                        low_tri, low_tri_idx[0], low_tri_idx[1])])
     # JAGUAR EIGENMATRIX
     filenames = chain.from_iterable(coms['jeigz'])
     for comma_sep_filenames in filenames:
@@ -1453,16 +1512,28 @@ def collect_data(coms, inps, direc='.', sub_names=['OPT'], invert=None):
         eigenmatrix = np.diag(eigenmatrix)
         low_tri_idx = np.tril_indices_from(eigenmatrix)
         low_tri = eigenmatrix[low_tri_idx]
-        data.extend([datatypes.Datum(
-                    val=e,
-                    com='jeigz',
-                    typ='eig',
-                    src_1=jin.filename,
-                    src_2=out.filename,
-                    idx_1=x + 1,
-                    idx_2=y + 1)
-                     for e, x, y in izip(
-                    low_tri, low_tri_idx[0], low_tri_idx[1])])
+        if (sys.version_info > (3, 0)):
+            data.extend([datatypes.Datum(
+                        val=e,
+                        com='jeigz',
+                        typ='eig',
+                        src_1=jin.filename,
+                        src_2=out.filename,
+                        idx_1=x + 1,
+                        idx_2=y + 1)
+                         for e, x, y in zip(
+                        low_tri, low_tri_idx[0], low_tri_idx[1])])
+        else:
+            data.extend([datatypes.Datum(
+                        val=e,
+                        com='jeigz',
+                        typ='eig',
+                        src_1=jin.filename,
+                        src_2=out.filename,
+                        idx_1=x + 1,
+                        idx_2=y + 1)
+                         for e, x, y in izip(
+                        low_tri, low_tri_idx[0], low_tri_idx[1])])
     # GAUSSIAN EIGENMATRIX
     filenames = chain.from_iterable(coms['geigz'])
     for filename in filenames:
@@ -1473,15 +1544,26 @@ def collect_data(coms, inps, direc='.', sub_names=['OPT'], invert=None):
         eigenmatrix = np.diag(evals)
         low_tri_idx = np.tril_indices_from(eigenmatrix)
         low_tri = eigenmatrix[low_tri_idx]
-        data.extend([datatypes.Datum(
-                    val=e,
-                    com='geigz',
-                    typ='eig',
-                    src_1=log.filename,
-                    idx_1=x + 1,
-                    idx_2=y + 1)
-                     for e, x, y in izip(
-                    low_tri, low_tri_idx[0], low_tri_idx[1])])
+        if (sys.version_info > (3, 0)):
+            data.extend([datatypes.Datum(
+                        val=e,
+                        com='geigz',
+                        typ='eig',
+                        src_1=log.filename,
+                        idx_1=x + 1,
+                        idx_2=y + 1)
+                         for e, x, y in zip(
+                        low_tri, low_tri_idx[0], low_tri_idx[1])])
+        else:
+            data.extend([datatypes.Datum(
+                        val=e,
+                        com='geigz',
+                        typ='eig',
+                        src_1=log.filename,
+                        idx_1=x + 1,
+                        idx_2=y + 1)
+                         for e, x, y in izip(
+                        low_tri, low_tri_idx[0], low_tri_idx[1])])
     # MACROMODEL EIGENMATRIX USING JAGUAR EIGENVECTORS
     filenames = chain.from_iterable(coms['mjeig'])
     for comma_sep_filenames in filenames:
@@ -1507,16 +1589,28 @@ def collect_data(coms, inps, direc='.', sub_names=['OPT'], invert=None):
             raise
         low_tri_idx = np.tril_indices_from(eigenmatrix)
         low_tri = eigenmatrix[low_tri_idx]
-        data.extend([datatypes.Datum(
-                    val=e,
-                    com='mjeig',
-                    typ='eig',
-                    src_1=mae.filename,
-                    src_2=out.filename,
-                    idx_1=x + 1,
-                    idx_2=y + 1)
-                     for e, x, y in izip(
-                    low_tri, low_tri_idx[0], low_tri_idx[1])])
+        if (sys.version_info > (3, 0)):
+            data.extend([datatypes.Datum(
+                        val=e,
+                        com='mjeig',
+                        typ='eig',
+                        src_1=mae.filename,
+                        src_2=out.filename,
+                        idx_1=x + 1,
+                        idx_2=y + 1)
+                         for e, x, y in zip(
+                        low_tri, low_tri_idx[0], low_tri_idx[1])])
+        else:
+            data.extend([datatypes.Datum(
+                        val=e,
+                        com='mjeig',
+                        typ='eig',
+                        src_1=mae.filename,
+                        src_2=out.filename,
+                        idx_1=x + 1,
+                        idx_2=y + 1)
+                         for e, x, y in izip(
+                        low_tri, low_tri_idx[0], low_tri_idx[1])])
     # MACROMODEL EIGENMATRIX USING GAUSSIAN EIGENVECTORS
     filenames = chain.from_iterable(coms['mgeig'])
     for comma_filenames in filenames:
@@ -1541,16 +1635,28 @@ def collect_data(coms, inps, direc='.', sub_names=['OPT'], invert=None):
             raise
         low_tri_idx = np.tril_indices_from(eigenmatrix)
         low_tri = eigenmatrix[low_tri_idx]
-        data.extend([datatypes.Datum(
-                    val=e,
-                    com='mgeig',
-                    typ='eig',
-                    src_1=name_mae,
-                    src_2=name_gau_log,
-                    idx_1=x + 1,
-                    idx_2=y + 1)
-                     for e, x, y in izip(
-                    low_tri, low_tri_idx[0], low_tri_idx[1])])
+        if (sys.version_info > (3, 0)):
+            data.extend([datatypes.Datum(
+                        val=e,
+                        com='mgeig',
+                        typ='eig',
+                        src_1=name_mae,
+                        src_2=name_gau_log,
+                        idx_1=x + 1,
+                        idx_2=y + 1)
+                         for e, x, y in zip(
+                        low_tri, low_tri_idx[0], low_tri_idx[1])])
+        else:
+            data.extend([datatypes.Datum(
+                        val=e,
+                        com='mgeig',
+                        typ='eig',
+                        src_1=name_mae,
+                        src_2=name_gau_log,
+                        idx_1=x + 1,
+                        idx_2=y + 1)
+                         for e, x, y in izip(
+                        low_tri, low_tri_idx[0], low_tri_idx[1])])
     logger.log(15, 'TOTAL DATA POINTS: {}'.format(len(data)))
     return np.array(data, dtype=datatypes.Datum)
 

--- a/q2mm/calculate.py
+++ b/q2mm/calculate.py
@@ -103,8 +103,12 @@ def main(args):
     #  'mb': [['a1.01.mae'], ['b1.01.mae']],
     #  'jeig': [['a1.01.in,a1.out', 'b1.01.in,b1.out']]
     # }
-    commands = {key: value for key, value in opts.__dict__.iteritems() if key
-                in COM_ALL and value}
+    if (sys.version_info > (3, 0)):
+        commands = {key: value for key, value in iter(opts.__dict__.items()) if key
+                    in COM_ALL and value}
+    else:
+        commands = {key: value for key, value in opts.__dict__.iteritems() if key
+                    in COM_ALL and value}
     # Add in the empty commands. I'd rather not do this, but it makes later
     # coding when collecting data easier.
     for command in COM_ALL:
@@ -144,7 +148,11 @@ def main(args):
     # commands_for_filenames, which contains all of the data types associated
     # with the given file.
     # Stuff below doesn't need both comma separated filenames simultaneously.
-    for filename, commands_for_filename in commands_for_filenames.iteritems():
+    if (sys.version_info > (3, 0)):
+        fname_cmds = iter(commands_for_filenames.items())
+    else:
+        fname_cmds = commands_for_filenames.iteritems()
+    for filename, commands_for_filename in fname_cmds:
         logger.log(1, '>>> filename: {}'.format(filename))
         logger.log(1, '>>> commands_for_filename: {}'.format(
             commands_for_filename))
@@ -1798,13 +1806,22 @@ def sort_commands_by_filename(commands):
     dictionary of the sorted commands
     '''
     sorted_commands = {}
-    for command, groups_filenames in commands.iteritems():
-        for comma_separated in chain.from_iterable(groups_filenames):
-            for filename in comma_separated.split(','):
-                if filename in sorted_commands:
-                    sorted_commands[filename].append(command)
-                else:
-                    sorted_commands[filename] = [command]
+    if (sys.version_info > (3, 0)):
+        for command, groups_filenames in iter(commands.items()):
+            for comma_separated in chain.from_iterable(groups_filenames):
+                for filename in comma_separated.split(','):
+                    if filename in sorted_commands:
+                        sorted_commands[filename].append(command)
+                    else:
+                        sorted_commands[filename] = [command]
+    else:
+        for command, groups_filenames in commands.iteritems():
+            for comma_separated in chain.from_iterable(groups_filenames):
+                for filename in comma_separated.split(','):
+                    if filename in sorted_commands:
+                        sorted_commands[filename].append(command)
+                    else:
+                        sorted_commands[filename] = [command]
     return sorted_commands
 
 # Will also have to be updated. Maybe the Datum class too and how it responds

--- a/q2mm/compare.py
+++ b/q2mm/compare.py
@@ -12,13 +12,14 @@ and :math:`x_c` is the calculated or force field's value for the data point.
 '''
 from __future__ import print_function
 from collections import defaultdict
-from itertools import izip
+import sys
+if (sys.version_info < (3, 0)):
+    from itertools import izip
 import argparse
 from argparse import RawTextHelpFormatter
 import logging
 import logging.config
 import numpy as np
-import sys
 
 import calculate
 import constants as co
@@ -51,11 +52,15 @@ def pretty_data_comp(r_data, c_data, output=None, doprint=False):
                    '--' + ' Weight '.center(7, '-') +
                    '--' + ' R. Value '.center(11, '-') +
                    '--' + ' C. Value '.center(11, '-') +
-                   '--' + ' Score '.center(11, '-') + 
+                   '--' + ' Score '.center(11, '-') +
                    '--' + ' Row ' + '--')
     score_typ = defaultdict(float)
     score_tot = 0.
-    for r, c in izip(r_data, c_data):
+    if (sys.version_info > (3, 0)):
+        rc_zip = zip(r_data, c_data)
+    else:
+        rc_zip = izip(r_data, c_data)
+    for r, c in rc_zip:
         # logger.log(1, '>>> {} {}'.format(r, c))
         # Double check data types.
         # Had to change to check from the FF data type because reference data
@@ -249,7 +254,11 @@ def calculate_score(r_data, c_data):
     Calculates the objective function score.
     """
     score_tot = 0.
-    for r_datum, c_datum in izip(r_data, c_data):
+    if (sys.version_info > (3, 0)):
+        rc_zip = zip(r_data, c_data)
+    else:
+        rc_zip = izip(r_data, c_data)
+    for r_datum, c_datum in rc_zip:
         # Could add a check here to assure that the data points are aligned.
         # Ex.) assert r_datum.ind_1 == c_datum.ind_1, 'Oh no!'
 

--- a/q2mm/compare.py
+++ b/q2mm/compare.py
@@ -85,13 +85,17 @@ def pretty_data_comp(r_data, c_data, output=None, doprint=False):
             else:
                 score_typ[c.typ + '-o'] += score
         strings.append('  {:<30}  {:>7.2f}  {:>11.4f}  {:>11.4f}  {:>11.4f}  '\
-                       '{:>5}  '.format(
+                       '{!s:>5}  '.format(
                         c.lbl, r.wht, r.val, c.val, score, c.ff_row))
     strings.append('-' * 89)
     strings.append('{:<20} {:20.4f}'.format('Total score:', score_tot))
     strings.append('{:<20} {:20d}'.format('Num. data points:', len(r_data)))
     strings.append('-' * 89)
-    for k, v in score_typ.iteritems():
+    if (sys.version_info > (3, 0)):
+        score_typ_iter = iter(score_typ.items())
+    else:
+        score_typ_iter = score_typ.iteritems()
+    for k, v in score_typ_iter:
         strings.append('{:<20} {:20.4f}'.format(k + ':', v))
     if output:
         with open(output, 'w') as f:

--- a/q2mm/datatypes.py
+++ b/q2mm/datatypes.py
@@ -499,7 +499,7 @@ class MM3(FF):
                             comment = line[COM_POS_START:].strip()
                             self.sub_names.append(comment)
                         parm_cols = line[P_1_START:P_3_END]
-                        parm_cols = map(float, parm_cols.split())
+                        parm_cols = list(map(float, parm_cols.split()))
                         self.params.append(
                             ParamMM3(atom_labels = atm_lbls,
                                      atom_types = atm_typs,
@@ -604,7 +604,7 @@ class MM3(FF):
                             comment = line[COM_POS_START:].strip()
                             self.sub_names.append(comment)
                         parm_cols = line[P_1_START:P_3_END]
-                        parm_cols = map(float, parm_cols.split())
+                        parm_cols = list(map(float, parm_cols.split()))
                         self.params.extend((
                             ParamMM3(atom_labels = atm_lbls,
                                      atom_types = atm_typs,

--- a/q2mm/datatypes.py
+++ b/q2mm/datatypes.py
@@ -415,7 +415,7 @@ class MM3(FF):
                             comment = line[COM_POS_START:].strip()
                             self.sub_names.append(comment)
                         parm_cols = line[P_1_START:P_3_END]
-                        parm_cols = map(float, parm_cols.split())
+                        parm_cols = list(map(float, parm_cols.split()))
                         self.params.extend((
                                 ParamMM3(atom_labels = atm_lbls,
                                          atom_types = atm_typs,
@@ -463,7 +463,7 @@ class MM3(FF):
                             comment = line[COM_POS_START:].strip()
                             self.sub_names.append(comment)
                         parm_cols = line[P_1_START:P_3_END]
-                        parm_cols = map(float, parm_cols.split())
+                        parm_cols = list(map(float, parm_cols.split()))
                         self.params.extend((
                             ParamMM3(atom_labels = atm_lbls,
                                      atom_types = atm_typs,
@@ -528,7 +528,7 @@ class MM3(FF):
                             comment = line[COM_POS_START:].strip()
                             self.sub_names.append(comment)
                         parm_cols = line[P_1_START:P_3_END]
-                        parm_cols = map(float, parm_cols.split())
+                        parm_cols = list(map(float, parm_cols.split()))
                         self.params.extend((
                             ParamMM3(atom_labels = atm_lbls,
                                      atom_types = atm_typs,
@@ -561,7 +561,7 @@ class MM3(FF):
                         atm_lbls = self.params[-1].atom_labels
                         atm_typs = self.params[-1].atom_types
                         parm_cols = line[P_1_START:P_3_END]
-                        parm_cols = map(float, parm_cols.split())
+                        parm_cols = list(map(float, parm_cols.split()))
                         self.params.extend((
                             ParamMM3(atom_labels = atm_lbls,
                                      atom_types = atm_typs,

--- a/q2mm/datatypes.py
+++ b/q2mm/datatypes.py
@@ -7,6 +7,7 @@ import logging
 import numpy as np
 import os
 import re
+import sys
 
 import constants as co
 import filetypes
@@ -95,10 +96,16 @@ class Param(object):
                 raise
         if self._step == 0.:
             self._step = 0.1
-        if isinstance(self._step, basestring):
-            return float(self._step) * self.value
+        if (sys.version_info > (3, 0)):
+            if isinstance(self._step, str):
+                return float(self._step) * self.value
+            else:
+                return self._step
         else:
-            return self._step
+            if isinstance(self._step, basestring):
+                return float(self._step) * self.value
+            else:
+                return self._step
     @step.setter
     def step(self, x):
         self._step = x

--- a/q2mm/filetypes.py
+++ b/q2mm/filetypes.py
@@ -30,8 +30,12 @@ import re
 import subprocess as sp
 import time
 
-from schrodinger import structure as sch_str
-from schrodinger.application.jaguar import input as jag_in
+try:
+    from schrodinger import structure as sch_str
+    from schrodinger.application.jaguar import input as jag_in
+except:
+    print("Schrodinger not installed, limited functionality")
+    pass
 
 import constants as co
 import datatypes

--- a/q2mm/filetypes.py
+++ b/q2mm/filetypes.py
@@ -29,6 +29,7 @@ import os
 import re
 import subprocess as sp
 import time
+import sys
 
 try:
     from schrodinger import structure as sch_str
@@ -1775,11 +1776,15 @@ class Mae(SchrodingerFile):
             while True:
                 token_string = sp.check_output(
                     '$SCHRODINGER/utilities/licutil -available', shell=True)
+                if (sys.version_info > (3, 0)):
+                  token_string = token_string.decode("utf-8")
                 if 'SUITE' not in token_string:
                     licenses_available = True
                     break
-                suite_tokens = re.search(co.LIC_SUITE, token_string)
-                macro_tokens = re.search(co.LIC_MACRO, token_string)
+                suite_tokens = co.LIC_SUITE.search(token_string)
+                macro_tokens = co.LIC_MACRO.search(token_string)
+                #suite_tokens = re.search(co.LIC_SUITE, token_string)
+                #macro_tokens = re.search(co.LIC_MACRO, token_string)
                 if not suite_tokens or not macro_tokens:
                     raise Exception(
                         'The command "$SCHRODINGER/utilities/licutil '
@@ -2046,7 +2051,10 @@ def select_structures(structures, indices, label):
         idx_iter = iter(indices)
         for str_num, struct in enumerate(structures):
             try:
-                idx_curr = idx_iter.next()
+                if (sys.version_info > (3, 0)):
+                    idx_curr = next(idx_iter)
+                else:
+                    idx_curr = idx_iter.next()
             except StopIteration:
                 idx_iter = iter(indices)
                 idx_curr = idx_iter.next()
@@ -2431,7 +2439,11 @@ class Bond(object):
         datum = datatypes.Datum(val=self.value, typ=typ,ff_row=self.ff_row)
         for i, atom_num in enumerate(self.atom_nums):
             setattr(datum, 'atm_{}'.format(i+1), atom_num)
-        for k, v in kwargs.iteritems():
+        if (sys.version_info > (3, 0)):
+            kwargs_iter = iter(kwargs.items())
+        else:
+            kwargs_iter = kwargs.iteritems()
+        for k, v in kwargs_iter:
             setattr(datum, k, v)
         return datum
 

--- a/q2mm/gradient.py
+++ b/q2mm/gradient.py
@@ -654,7 +654,7 @@ def return_jacobian(jacob, par_file):
     with open(par_file, 'r') as f:
         logger.log(15, 'READING: {}'.format(par_file))
         f.readline() # Labels.
-        whts = map(float, f.readline().split(',')) # Weights.
+        whts = list(map(float, f.readline().split(','))) # Weights.
         f.readline() # Reference values.
         f.readline() # Original values.
         # This is only for central differentiation.
@@ -726,9 +726,9 @@ def update_params(params, changes):
     """
     try:
         if (sys.version_info > (3, 0)):
-            zip_param_changes = zip(params, changes)
+            zip_params_changes = zip(params, changes)
         else:
-            zip_param_changes = itertools.izip(params, changes)
+            zip_params_changes = itertools.izip(params, changes)
         for param, change in zip_params_changes:
             param.value += change * param.step
     except datatypes.ParamError as e:

--- a/q2mm/gradient.py
+++ b/q2mm/gradient.py
@@ -8,6 +8,7 @@ import logging.config
 import numpy as np
 import os
 import re
+import sys
 
 import calculate
 import compare
@@ -209,7 +210,7 @@ class Gradient(opt.Optimizer):
             # Setup the residual vector.
             num_d = len(ref_data)
             resid = np.empty((num_d, 1), dtype=float)
-            for i in xrange(0, num_d):
+            for i in range(0, num_d):
                 resid[i, 0] = ref_data[i].wht * \
                               (ref_data[i].val - self.ff.data[i].val)
             # logger.log(5, 'RESIDUAL VECTOR:\n{}'.format(resid))
@@ -306,7 +307,7 @@ class Gradient(opt.Optimizer):
 def copy_derivs(new_ff, old_ff):
     num_params = len(new_ff.params)
     assert num_params == len(old_ff.params)
-    for i in xrange(0, num_params):
+    for i in range(0, num_params):
         new_ff.params[i].d1 = old_ff.params[i].d1
         new_ff.params[i].d2 = old_ff.params[i].d2
     logger.log(20, '  -- Copied parameter derivatives from {} to {}.'.format(
@@ -514,7 +515,7 @@ def do_svd_w_thresholds(mu, vs, mvt, resid, factors):
         old_msi = copy.deepcopy(msi)
         logger.log(1, '>>> msi:\n{}'.format(msi))
         logger.log(1, '>>> old_msi:\n{}'.format(old_msi))
-        for i in xrange(0, len(vs)):
+        for i in range(0, len(vs)):
             if msi[i, i] > factor:
                 msi[i, i] = 0.
         logger.log(1, '>>> msi:\n{}'.format(msi))
@@ -576,7 +577,7 @@ def do_svd_wo_thresholds(mu, vs, mvt, resid):
     logger.log(1, '>>> changes:\n{}'.format(changes))
     all_changes.append(('SVD Z0', changes))
 
-    for i in xrange(0, len(vs) - 1):
+    for i in range(0, len(vs) - 1):
         # Save a copy to check whether or not anything actually changes after
         # zeroing.
         old_msi = copy.deepcopy(msi)
@@ -665,8 +666,12 @@ def return_jacobian(jacob, par_file):
                 break
             inc_data = map(float, l1.split(','))
             dec_data = map(float, l2.split(','))
+            if (sys.version_info > (3, 0)):
+                data_zip = zip(inc_data, dec_data)
+            else:
+                data_zip = itertools.izip(inc_data, dec_data)
             for data_ind, (inc_datum, dec_datum) in \
-                    enumerate(itertools.izip(inc_data, dec_data)):
+                    enumerate(data_zip):
                 dydp = (inc_datum - dec_datum) / 2
                 jacob[data_ind, ff_ind] = whts[data_ind] * dydp
             ff_ind += 1
@@ -720,7 +725,11 @@ def update_params(params, changes):
                     Unscaled changes to the parameter values.
     """
     try:
-        for param, change in itertools.izip(params, changes):
+        if (sys.version_info > (3, 0)):
+            zip_param_changes = zip(params, changes)
+        else:
+            zip_param_changes = itertools.izip(params, changes)
+        for param, change in zip_params_changes:
             param.value += change * param.step
     except datatypes.ParamError as e:
         logger.warning(e.message)

--- a/q2mm/loop.py
+++ b/q2mm/loop.py
@@ -111,10 +111,16 @@ class Loop(object):
             if cols[0] == 'LOOP':
                 # Read lines that will be looped over.
                 inner_loop_lines = []
-                line = lines_iterator.next()
+                if (sys.version_info > (3, 0)):
+                    line = next(lines_iterator)
+                else:
+                    line = lines_iterator.next()
                 while line.split()[0] != 'END':
                     inner_loop_lines.append(line)
-                    line = lines_iterator.next()
+                    if (sys.version_info > (3, 0)):
+                        line = next(lines_iterator)
+                    else:
+                        line = lines_iterator.next()
                 # Make loop object and populate attributes.
                 loop = Loop()
                 loop.convergence = float(cols[1])

--- a/q2mm/loop.py
+++ b/q2mm/loop.py
@@ -83,7 +83,10 @@ class Loop(object):
         lines_iterator = iter(lines)
         while True:
             try:
-                line = lines_iterator.next()
+                if (sys.version_info > (3, 0)):
+                    line = next(lines_iterator)
+                else:
+                    line = lines_iterator.next()
             except StopIteration:
                 return self.ff
             cols = line.split()

--- a/q2mm/opt.py
+++ b/q2mm/opt.py
@@ -261,10 +261,13 @@ def param_derivs(ff, ffs):
     ffs : list of `datatypes.FF` (or subclass)
           Central differentiated and scored force fields.
     """
-    for i in xrange(0, len(ffs), 2):
+    # Reverting xrange() to range() as range() in python3 is equivalent to
+    # xrange() in python2. I don't expect the extra memory needed for range()
+    # in python2 will be significant here and syntactically this is simpler
+    for i in range(0, len(ffs), 2):
         logger.log(1, '>>> ffs[i].score: {}'.format(ffs[i].score))
-        ff.params[i/2].d1 = (ffs[i].score - ffs[i+1].score) * 0.5 # 18
-        ff.params[i/2].d2 = ffs[i].score + ffs[i+1].score - 2 * ff.score # 19
+        ff.params[int(i/2)].d1 = (ffs[i].score - ffs[i+1].score) * 0.5 # 18
+        ff.params[int(i/2)].d2 = ffs[i].score + ffs[i+1].score - 2 * ff.score # 19
     pretty_derivs(ff.params)
 
 def cal_ff(ff, ff_args, parent_ff=None, store_data=False):
@@ -329,7 +332,7 @@ def pretty_ff_params(ffs, level=20):
             '--' + ' PARAMETER '.ljust(25, '-') +
             '--' + ' VALUES '.ljust(48, '-') +
             '--')
-        for i in xrange(0, len(ffs[0].params)):
+        for i in range(0, len(ffs[0].params)):
             wrapper.initial_indent = ' {:25s} '.format(repr(ffs[0].params[i]))
             all_param_values = [x.params[i].value for x in ffs]
             all_param_values = ['{:8.4f}'.format(x) for x in all_param_values]

--- a/q2mm/opt.py
+++ b/q2mm/opt.py
@@ -9,6 +9,7 @@ import logging.config
 import numpy as np
 import re
 import textwrap
+import sys
 
 import calculate
 import compare
@@ -374,7 +375,11 @@ def pretty_param_changes(params, changes, method=None, level=20):
             '--')
         # This calculation of the real parameter step size is also repeated.
         # The things I do for a good looking log.
-        for param, change in itertools.izip(params, changes):
+        if (sys.version_info > (3, 0)):
+            zip_param_change = zip(params, changes)
+        else:
+            zip_param_change = itertools.izip(params, changes)
+        for param, change in zip_param_change:
             logger.log(
                 level,
                 '  ' + '{}'.format(param).ljust(34, ' ') +

--- a/q2mm/parameters.py
+++ b/q2mm/parameters.py
@@ -183,7 +183,7 @@ def read_param_file(filename):
                 elif cols[2:]:
                     # Selects all values after 2 as a list, and then
                     # trims to only 2 values.
-                    allowed_range = map(float, cols[2:][:2])
+                    allowed_range = list(map(float, cols[2:][:2]))
                 else:
                     allowed_range = None
                 # Add information to the temporary list.
@@ -228,6 +228,8 @@ def main(args):
     Imports a force field object, which contains a list of all the available
     parameters. Returns a list of only the user selected parameters.
     '''
+    # basestring is deprecated in python3, str is probably safe to use in both
+    # but should be tested, for now sys.version_info switch can handle it
     if (sys.version_info > (3, 0)):
         if isinstance(args, str):
             args = args.split()

--- a/q2mm/parameters.py
+++ b/q2mm/parameters.py
@@ -228,8 +228,12 @@ def main(args):
     Imports a force field object, which contains a list of all the available
     parameters. Returns a list of only the user selected parameters.
     '''
-    if isinstance(args, basestring):
-        args = args.split()
+    if (sys.version_info > (3, 0)):
+        if isinstance(args, str):
+            args = args.split()
+    else:
+        if isinstance(args, basestring):
+            args = args.split()
     parser = return_params_parser()
     opts = parser.parse_args(args)
     if opts.average or opts.check:


### PR DESCRIPTION
These changes should allow Q2MM to run with both python 2 and 3 now. I have not fully tested it yet because I am waiting on the provided example to complete which I have running on the CRC nodes, but if anything I am fairly certain that it would only throw exceptions if using python 3 and python 2 should still work fine. Since the example only used gradient descent then simplex probably won't work in python 3 yet, but that should be easy enough to change as needed.

Though I think this will work, it's certainly a messy way of making it compatible with both versions. I think a much cleaner way would just be to revert a lot of the functions to their non-iterator version (e.g. just use `zip()` instead of `itertools.izip()`) since in python 3 these methods are changed into iterators anyway. This would eliminate the need for `if sys.version_info > (3, 0))` checks in a lot of places. I don't imagine the memory usage would go up significantly in most parts of the code, but I didn't want to break anything and slow down anyone's work with bugs in the code, so that is something that can be done later.