### PR TITLE
Better python2/3 compatabilities, coding styles

### DIFF
--- a/q2mm/calculate.py
+++ b/q2mm/calculate.py
@@ -13,6 +13,9 @@ Mae class inside filetypes. I'm still debating if that should be
 there or here. Will see how this framework translates into
 Amber and then decide.
 """
+from __future__ import absolute_import
+from __future__ import division
+
 import argparse
 import logging
 import logging.config
@@ -25,17 +28,14 @@ import sys
 # chain.from_iterable flattens a list of lists similar to:
 #   [child for parent in grandparent for child in parent]
 # However, I think chain.from_iterable works on any number of nested lists.
-if (sys.version_info > (3, 0)):
-    from itertools import chain
-else:
-    from itertools import chain, izip
+from itertools import chain
 from textwrap import TextWrapper
 
-import constants as co
-import compare
-import datatypes
-import filetypes
-import parameters
+import .constants as co
+import .compare
+import .datatypes
+import .filetypes
+import .parameters
 
 logger = logging.getLogger(__name__)
 
@@ -83,7 +83,7 @@ def main(args):
     # Should be a list of strings for use by argparse. Ensure that's the case.
     # basestring is deprecated in python3, str is probably safe to use in both
     # but should be tested, for now sys.version_info switch can handle it
-    if (sys.version_info > (3, 0)):
+    if sys.version_info > (3, 0):
         if isinstance(args, str):
             args = args.split()
     else:
@@ -103,12 +103,8 @@ def main(args):
     #  'mb': [['a1.01.mae'], ['b1.01.mae']],
     #  'jeig': [['a1.01.in,a1.out', 'b1.01.in,b1.out']]
     # }
-    if (sys.version_info > (3, 0)):
-        commands = {key: value for key, value in iter(opts.__dict__.items()) if key
-                    in COM_ALL and value}
-    else:
-        commands = {key: value for key, value in opts.__dict__.iteritems() if key
-                    in COM_ALL and value}
+    commands = {key: value for key, value in opts.__dict__.items() if key
+                in COM_ALL and value}
     # Add in the empty commands. I'd rather not do this, but it makes later
     # coding when collecting data easier.
     for command in COM_ALL:
@@ -148,11 +144,7 @@ def main(args):
     # commands_for_filenames, which contains all of the data types associated
     # with the given file.
     # Stuff below doesn't need both comma separated filenames simultaneously.
-    if (sys.version_info > (3, 0)):
-        fname_cmds = iter(commands_for_filenames.items())
-    else:
-        fname_cmds = commands_for_filenames.iteritems()
-    for filename, commands_for_filename in fname_cmds:
+    for filename, commands_for_filename in commands_for_filenames.items():
         logger.log(1, '>>> filename: {}'.format(filename))
         logger.log(1, '>>> commands_for_filename: {}'.format(
             commands_for_filename))
@@ -207,11 +199,7 @@ def main(args):
     if opts.norun or opts.fake:
         logger.log(15, "  -- Skipping backend calculations.")
     else:
-        if (sys.version_info > (3, 0)):
-            inps_iter = iter(inps.items())
-        else:
-            inps_iter = inps.iteritems()
-        for filename, some_class in inps_iter:
+        for filename, some_class in inps.items():
             logger.log(1, '>>> filename: {}'.format(filename))
             logger.log(1, '>>> some_class: {}'.format(some_class))
             # Works if some class is None too.
@@ -714,7 +702,7 @@ def collect_data(coms, inps, direc='.', sub_names=['OPT'], invert=None):
                 if ',' in thing:
                     # Note that the "stupidproperty" example would fail here
                     # because its elements can not be converted to floats.
-                    thing = map(float, thing.split(','))
+                    thing = [float(x) for x in thing.split(',')]
                     # Here, thing might look like:
                     #    thing = [0.1235235, 0.2352, 0.352345]
                 else:
@@ -869,7 +857,7 @@ def collect_data(coms, inps, direc='.', sub_names=['OPT'], invert=None):
             for thing_label in co.GAUSSIAN_ENERGIES:
                 thing = log.structures[0].props[thing_label]
                 if ',' in thing:
-                    thing = map(float, thing.split(','))
+                    thing = [float(x) for x in thing.split(',')]
                 else:
                     thing = [float(thing)]
                 things_to_add.append(thing)
@@ -953,7 +941,7 @@ def collect_data(coms, inps, direc='.', sub_names=['OPT'], invert=None):
             for thing_label in co.GAUSSIAN_ENERGIES:
                 thing = log.structures[0].props[thing_label]
                 if ',' in thing:
-                    thing = map(float, thing.split(','))
+                    thing = [float(x) for x in thing.split(',')]
                 else:
                     thing = [float(thing)]
                 things_to_add.append(thing)
@@ -1028,7 +1016,7 @@ def collect_data(coms, inps, direc='.', sub_names=['OPT'], invert=None):
             for thing_label in co.GAUSSIAN_ENERGIES:
                 thing = log.structures[0].props[thing_label]
                 if ',' in thing:
-                    thing = map(float, thing.split(','))
+                    thing = [float(x) for x in thing.split(',')]
                 else:
                     thing = [float(thing)]
                 things_to_add.append(thing)
@@ -1165,26 +1153,15 @@ def collect_data(coms, inps, direc='.', sub_names=['OPT'], invert=None):
         # I'm not even sure if we can use dummy atoms in TINKER.
         low_tri_idx = np.tril_indices_from(hess)
         low_tri = hess[low_tri_idx]
-        if (sys.version_info > (3, 0)):
-            data.extend([datatypes.Datum(
-                val=e,
-                com='th',
-                typ='h',
-                src_1=hes.filename,
-                idx_1=x + 1,
-                idx_2=y + 1)
-                    for e, x, y in zip(
-                        low_tri, low_tri_idx[0], low_tri_idx[1])])
-        else:
-            data.extend([datatypes.Datum(
-                val=e,
-                com='th',
-                typ='h',
-                src_1=hes.filename,
-                idx_1=x + 1,
-                idx_2=y + 1)
-                    for e, x, y in izip(
-                        low_tri, low_tri_idx[0], low_tri_idx[1])])
+        data.extend([datatypes.Datum(
+            val=e,
+            com='th',
+            typ='h',
+            src_1=hes.filename,
+            idx_1=x + 1,
+            idx_2=y + 1)
+                for e, x, y in zip(
+                    low_tri, low_tri_idx[0], low_tri_idx[1])])
     # TINKER EIGENMATRIX USING GAUSSIAN EIGENVECTORS
     filenames = chain.from_iterable(coms['tgeig'])
     for comma_filenames in filenames:
@@ -1210,28 +1187,16 @@ def collect_data(coms, inps, direc='.', sub_names=['OPT'], invert=None):
             raise
         low_tri_idx = np.tril_indices_from(eigenmatrix)
         low_tri = eigenmatrix[low_tri_idx]
-        if (sys.version_info > (3, 0)):
-            data.extend([datatypes.Datum(
-                val=e,
-                com='tgeig',
-                typ='eig',
-                src_1=name_xyz,
-                src_2=name_gau_log,
-                idx_1=x + 1,
-                idx_2=y + 1)
-                    for e, x, y in zip(
-                        low_tri, low_tri_idx[0], low_tri_idx[1])])
-        else:
-            data.extend([datatypes.Datum(
-                val=e,
-                com='tgeig',
-                typ='eig',
-                src_1=name_xyz,
-                src_2=name_gau_log,
-                idx_1=x + 1,
-                idx_2=y + 1)
-                    for e, x, y in izip(
-                        low_tri, low_tri_idx[0], low_tri_idx[1])])
+        data.extend([datatypes.Datum(
+            val=e,
+            com='tgeig',
+            typ='eig',
+            src_1=name_xyz,
+            src_2=name_gau_log,
+            idx_1=x + 1,
+            idx_2=y + 1)
+                for e, x, y in zip(
+                    low_tri, low_tri_idx[0], low_tri_idx[1])])
     # MACROMODEL BONDS
     filenames = chain.from_iterable(coms['mb'])
     for filename in filenames:
@@ -1493,26 +1458,15 @@ def collect_data(coms, inps, direc='.', sub_names=['OPT'], invert=None):
         datatypes.replace_minimum(hess, value=invert)
         low_tri_idx = np.tril_indices_from(hess)
         low_tri = hess[low_tri_idx]
-        if (sys.version_info > (3, 0)):
-            data.extend([datatypes.Datum(
-                        val=e,
-                        com='jh',
-                        typ='h',
-                        src_1=jin.filename,
-                        idx_1=x + 1,
-                        idx_2=y + 1)
-                         for e, x, y in zip(
-                        low_tri, low_tri_idx[0], low_tri_idx[1])])
-        else:
-            data.extend([datatypes.Datum(
-                        val=e,
-                        com='jh',
-                        typ='h',
-                        src_1=jin.filename,
-                        idx_1=x + 1,
-                        idx_2=y + 1)
-                         for e, x, y in izip(
-                        low_tri, low_tri_idx[0], low_tri_idx[1])])
+        data.extend([datatypes.Datum(
+                    val=e,
+                    com='jh',
+                    typ='h',
+                    src_1=jin.filename,
+                    idx_1=x + 1,
+                    idx_2=y + 1)
+                     for e, x, y in zip(
+                    low_tri, low_tri_idx[0], low_tri_idx[1])])
     # GAUSSIAN HESSIAN
     filenames = chain.from_iterable(coms['gh'])
     for filename in filenames:
@@ -1533,26 +1487,15 @@ def collect_data(coms, inps, direc='.', sub_names=['OPT'], invert=None):
         # WARNING: This option may need to be mass weighted!
         low_tri_idx = np.tril_indices_from(hess)
         low_tri = hess[low_tri_idx]
-        if (sys.version_info > (3, 0)):
-            data.extend([datatypes.Datum(
-                        val=e,
-                        com='gh',
-                        typ='h',
-                        src_1=log.filename,
-                        idx_1=x + 1,
-                        idx_2=y + 1)
-                         for e, x, y in zip(
-                        low_tri, low_tri_idx[0], low_tri_idx[1])])
-        else:
-            data.extend([datatypes.Datum(
-                        val=e,
-                        com='gh',
-                        typ='h',
-                        src_1=log.filename,
-                        idx_1=x + 1,
-                        idx_2=y + 1)
-                         for e, x, y in izip(
-                        low_tri, low_tri_idx[0], low_tri_idx[1])])
+        data.extend([datatypes.Datum(
+                    val=e,
+                    com='gh',
+                    typ='h',
+                    src_1=log.filename,
+                    idx_1=x + 1,
+                    idx_2=y + 1)
+                     for e, x, y in zip(
+                    low_tri, low_tri_idx[0], low_tri_idx[1])])
     # MACROMODEL HESSIAN
     filenames = chain.from_iterable(coms['mh'])
     for filename in filenames:
@@ -1568,26 +1511,15 @@ def collect_data(coms, inps, direc='.', sub_names=['OPT'], invert=None):
         hess = datatypes.check_mm_dummy(hess, hess_dummies)
         low_tri_idx = np.tril_indices_from(hess)
         low_tri = hess[low_tri_idx]
-        if (sys.version_info > (3, 0)):
-            data.extend([datatypes.Datum(
-                        val=e,
-                        com='mh',
-                        typ='h',
-                        src_1=mae.filename,
-                        idx_1=x + 1,
-                        idx_2=y + 1)
-                         for e, x, y in zip(
-                        low_tri, low_tri_idx[0], low_tri_idx[1])])
-        else:
-            data.extend([datatypes.Datum(
-                        val=e,
-                        com='mh',
-                        typ='h',
-                        src_1=mae.filename,
-                        idx_1=x + 1,
-                        idx_2=y + 1)
-                         for e, x, y in izip(
-                        low_tri, low_tri_idx[0], low_tri_idx[1])])
+        data.extend([datatypes.Datum(
+                    val=e,
+                    com='mh',
+                    typ='h',
+                    src_1=mae.filename,
+                    idx_1=x + 1,
+                    idx_2=y + 1)
+                     for e, x, y in zip(
+                    low_tri, low_tri_idx[0], low_tri_idx[1])])
     # JAGUAR EIGENMATRIX
     filenames = chain.from_iterable(coms['jeigz'])
     for comma_sep_filenames in filenames:
@@ -1619,28 +1551,16 @@ def collect_data(coms, inps, direc='.', sub_names=['OPT'], invert=None):
         eigenmatrix = np.diag(eigenmatrix)
         low_tri_idx = np.tril_indices_from(eigenmatrix)
         low_tri = eigenmatrix[low_tri_idx]
-        if (sys.version_info > (3, 0)):
-            data.extend([datatypes.Datum(
-                        val=e,
-                        com='jeigz',
-                        typ='eig',
-                        src_1=jin.filename,
-                        src_2=out.filename,
-                        idx_1=x + 1,
-                        idx_2=y + 1)
-                         for e, x, y in zip(
-                        low_tri, low_tri_idx[0], low_tri_idx[1])])
-        else:
-            data.extend([datatypes.Datum(
-                        val=e,
-                        com='jeigz',
-                        typ='eig',
-                        src_1=jin.filename,
-                        src_2=out.filename,
-                        idx_1=x + 1,
-                        idx_2=y + 1)
-                         for e, x, y in izip(
-                        low_tri, low_tri_idx[0], low_tri_idx[1])])
+        data.extend([datatypes.Datum(
+                    val=e,
+                    com='jeigz',
+                    typ='eig',
+                    src_1=jin.filename,
+                    src_2=out.filename,
+                    idx_1=x + 1,
+                    idx_2=y + 1)
+                     for e, x, y in zip(
+                    low_tri, low_tri_idx[0], low_tri_idx[1])])
     # GAUSSIAN EIGENMATRIX
     filenames = chain.from_iterable(coms['geigz'])
     for filename in filenames:
@@ -1651,26 +1571,15 @@ def collect_data(coms, inps, direc='.', sub_names=['OPT'], invert=None):
         eigenmatrix = np.diag(evals)
         low_tri_idx = np.tril_indices_from(eigenmatrix)
         low_tri = eigenmatrix[low_tri_idx]
-        if (sys.version_info > (3, 0)):
-            data.extend([datatypes.Datum(
-                        val=e,
-                        com='geigz',
-                        typ='eig',
-                        src_1=log.filename,
-                        idx_1=x + 1,
-                        idx_2=y + 1)
-                         for e, x, y in zip(
-                        low_tri, low_tri_idx[0], low_tri_idx[1])])
-        else:
-            data.extend([datatypes.Datum(
-                        val=e,
-                        com='geigz',
-                        typ='eig',
-                        src_1=log.filename,
-                        idx_1=x + 1,
-                        idx_2=y + 1)
-                         for e, x, y in izip(
-                        low_tri, low_tri_idx[0], low_tri_idx[1])])
+        data.extend([datatypes.Datum(
+                    val=e,
+                    com='geigz',
+                    typ='eig',
+                    src_1=log.filename,
+                    idx_1=x + 1,
+                    idx_2=y + 1)
+                     for e, x, y in zip(
+                    low_tri, low_tri_idx[0], low_tri_idx[1])])
     # MACROMODEL EIGENMATRIX USING JAGUAR EIGENVECTORS
     filenames = chain.from_iterable(coms['mjeig'])
     for comma_sep_filenames in filenames:
@@ -1696,28 +1605,16 @@ def collect_data(coms, inps, direc='.', sub_names=['OPT'], invert=None):
             raise
         low_tri_idx = np.tril_indices_from(eigenmatrix)
         low_tri = eigenmatrix[low_tri_idx]
-        if (sys.version_info > (3, 0)):
-            data.extend([datatypes.Datum(
-                        val=e,
-                        com='mjeig',
-                        typ='eig',
-                        src_1=mae.filename,
-                        src_2=out.filename,
-                        idx_1=x + 1,
-                        idx_2=y + 1)
-                         for e, x, y in zip(
-                        low_tri, low_tri_idx[0], low_tri_idx[1])])
-        else:
-            data.extend([datatypes.Datum(
-                        val=e,
-                        com='mjeig',
-                        typ='eig',
-                        src_1=mae.filename,
-                        src_2=out.filename,
-                        idx_1=x + 1,
-                        idx_2=y + 1)
-                         for e, x, y in izip(
-                        low_tri, low_tri_idx[0], low_tri_idx[1])])
+        data.extend([datatypes.Datum(
+                    val=e,
+                    com='mjeig',
+                    typ='eig',
+                    src_1=mae.filename,
+                    src_2=out.filename,
+                    idx_1=x + 1,
+                    idx_2=y + 1)
+                     for e, x, y in zip(
+                    low_tri, low_tri_idx[0], low_tri_idx[1])])
     # MACROMODEL EIGENMATRIX USING GAUSSIAN EIGENVECTORS
     filenames = chain.from_iterable(coms['mgeig'])
     for comma_filenames in filenames:
@@ -1742,28 +1639,16 @@ def collect_data(coms, inps, direc='.', sub_names=['OPT'], invert=None):
             raise
         low_tri_idx = np.tril_indices_from(eigenmatrix)
         low_tri = eigenmatrix[low_tri_idx]
-        if (sys.version_info > (3, 0)):
-            data.extend([datatypes.Datum(
-                        val=e,
-                        com='mgeig',
-                        typ='eig',
-                        src_1=name_mae,
-                        src_2=name_gau_log,
-                        idx_1=x + 1,
-                        idx_2=y + 1)
-                         for e, x, y in zip(
-                        low_tri, low_tri_idx[0], low_tri_idx[1])])
-        else:
-            data.extend([datatypes.Datum(
-                        val=e,
-                        com='mgeig',
-                        typ='eig',
-                        src_1=name_mae,
-                        src_2=name_gau_log,
-                        idx_1=x + 1,
-                        idx_2=y + 1)
-                         for e, x, y in izip(
-                        low_tri, low_tri_idx[0], low_tri_idx[1])])
+        data.extend([datatypes.Datum(
+                    val=e,
+                    com='mgeig',
+                    typ='eig',
+                    src_1=name_mae,
+                    src_2=name_gau_log,
+                    idx_1=x + 1,
+                    idx_2=y + 1)
+                     for e, x, y in zip(
+                    low_tri, low_tri_idx[0], low_tri_idx[1])])
     logger.log(15, 'TOTAL DATA POINTS: {}'.format(len(data)))
     return np.array(data, dtype=datatypes.Datum)
 
@@ -1775,7 +1660,7 @@ def collect_data_fake(coms, inps, direc='.', sub_names=['OPT']):
     data = []
     filenames = flatten(coms.values())
     for idx_1, filename in enumerate(filenames):
-        for idx_2 in xrange(5):
+        for idx_2 in range(5):
             data.append(datatypes.Datum(
                     val=random.uniform(0, 10),
                     com='rand',
@@ -1797,13 +1682,21 @@ def flatten(l):
     """
     # Move this?
     import collections
-    for el in l:
-        if isinstance(el, collections.Iterable) and \
-          not isinstance(el, basestring):
-            for sub in flatten(el):
-                yield sub
-        else:
-            yield el
+    if sys.version_info > (3, 0):
+        for el in l:
+            if isinstance(el, collections.Iterable) and \
+                    not isinstance(el, (str, bytes)):
+                yield from flatten(el):
+            else:
+                yield el
+    else:
+        for el in l:
+            if isinstance(el, collections.Iterable) and \
+              not isinstance(el, basestring):
+                for sub in flatten(el):
+                    yield sub
+            else:
+                yield el
 
 def collect_structural_data_from_mae(
     name_mae, inps, outs, direc, sub_names, com, ind, typ):
@@ -1899,22 +1792,13 @@ def sort_commands_by_filename(commands):
     dictionary of the sorted commands
     '''
     sorted_commands = {}
-    if (sys.version_info > (3, 0)):
-        for command, groups_filenames in iter(commands.items()):
-            for comma_separated in chain.from_iterable(groups_filenames):
-                for filename in comma_separated.split(','):
-                    if filename in sorted_commands:
-                        sorted_commands[filename].append(command)
-                    else:
-                        sorted_commands[filename] = [command]
-    else:
-        for command, groups_filenames in commands.iteritems():
-            for comma_separated in chain.from_iterable(groups_filenames):
-                for filename in comma_separated.split(','):
-                    if filename in sorted_commands:
-                        sorted_commands[filename].append(command)
-                    else:
-                        sorted_commands[filename] = [command]
+    for command, groups_filenames in commands.items():
+        for comma_separated in chain.from_iterable(groups_filenames):
+            for filename in comma_separated.split(','):
+                if filename in sorted_commands:
+                    sorted_commands[filename].append(command)
+                else:
+                    sorted_commands[filename] = [command]
     return sorted_commands
 
 # Will also have to be updated. Maybe the Datum class too and how it responds
@@ -1991,7 +1875,7 @@ def pretty_commands_for_files(commands_for_files, log_level=5):
             '--' + ' FILENAME '.center(22, '-') +
             '--' + ' COMMANDS '.center(22, '-') +
             '--')
-        for filename, commands in commands_for_files.iteritems():
+        for filename, commands in commands_for_files.items():
             foobar.initial_indent = '  {:22s}  '.format(filename)
             logger.log(log_level, foobar.fill(' '.join(commands)))
         logger.log(log_level, '-'*50)
@@ -2015,7 +1899,7 @@ def pretty_all_commands(commands, log_level=5):
             '--' + ' GROUP # '.center(9, '-') +
             '--' + ' FILENAMES '.center(24, '-') +
             '--')
-        for command, groups_filenames in commands.iteritems():
+        for command, groups_filenames in commands.items():
             for i, filenames in enumerate(groups_filenames):
                 if i == 0:
                     foobar.initial_indent = \

--- a/q2mm/compare.py
+++ b/q2mm/compare.py
@@ -11,19 +11,18 @@ and :math:`x_c` is the calculated or force field's value for the data point.
 
 '''
 from __future__ import print_function
+from __future__ import absolute_import
 from collections import defaultdict
 import sys
-if (sys.version_info < (3, 0)):
-    from itertools import izip
 import argparse
 from argparse import RawTextHelpFormatter
 import logging
 import logging.config
 import numpy as np
 
-import calculate
-import constants as co
-import datatypes
+import .calculate
+import .constants as co
+import .datatypes
 
 logger = logging.getLogger(__name__)
 
@@ -140,11 +139,7 @@ def compare_data(r_dict, c_dict, output=None, doprint=False):
         if typ in ['e','eo','ea','eao']:
             correlate_energies(r_dict[typ],c_dict[typ])
         import_weights(r_dict[typ])
-        if (sys.version_info > (3,0)):
-            rc_zip = zip(r_dict[typ],c_dict[typ])
-        else:
-            rc_zip = izip(r_dict[typ],c_dict[typ])
-        for r,c in rc_zip:
+        for r,c in zip(r_dict[typ],c_dict[typ]):
             if c.typ == 't':
                 diff = abs(r.val - c.val)
                 if diff > 180.:
@@ -176,14 +171,10 @@ def compare_data(r_dict, c_dict, output=None, doprint=False):
     strings.append('-' * 89)
     strings.append('{:<20} {:20.4f}'.format('Total score:', score_tot))
     strings.append('{:<30} {:10d}'.format('Total Num. data points:', total_num))
-    for k, v in num_typ.iteritems():
+    for k, v in num_typ.items():
         strings.append('{:<30} {:10d}'.format(k + ':', v))
     strings.append('-' * 89)
-    if (sys.version_info > (3, 0)):
-        score_typ_iter = iter(score_typ.items())
-    else:
-        score_typ_iter = score_typ.iteritems()
-    for k, v in score_typ_iter:
+    for k, v in score_typ.items():
         strings.append('{:<20} {:20.4f}'.format(k + ':', v))
     if output:
         with open(output, 'w') as f:
@@ -353,11 +344,7 @@ def calculate_score(r_data, c_data):
     Calculates the objective function score.
     """
     score_tot = 0.
-    if (sys.version_info > (3, 0)):
-        rc_zip = zip(r_data, c_data)
-    else:
-        rc_zip = izip(r_data, c_data)
-    for r_datum, c_datum in rc_zip:
+    for r_datum, c_datum in zip(r_data, c_data):
         # Could add a check here to assure that the data points are aligned.
         # Ex.) assert r_datum.ind_1 == c_datum.ind_1, 'Oh no!'
 

--- a/q2mm/datatypes.py
+++ b/q2mm/datatypes.py
@@ -2,6 +2,9 @@
 Contains basic data structures used throughout the rest of Q2MM.
 """
 from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import division
+
 import copy
 import logging
 import numpy as np
@@ -9,8 +12,8 @@ import os
 import re
 import sys
 
-import constants as co
-import filetypes
+import .constants as co
+import .filetypes
 
 logger = logging.getLogger(__name__)
 
@@ -96,7 +99,7 @@ class Param(object):
                 raise
         if self._step == 0.:
             self._step = 0.1
-        if (sys.version_info > (3, 0)):
+        if sys.version_info > (3, 0):
             if isinstance(self._step, str):
                 return float(self._step) * self.value
             else:
@@ -195,10 +198,9 @@ class Datum(object):
             # Why would it ever not have src_1?
             else:
                 b = None
-            c = '-'.join(map(str, remove_none(
-                        self.idx_1, self.idx_2)))
-            d = '-'.join(map(str, remove_none(
-                        self.atm_1, self.atm_2, self.atm_3, self.atm_4)))
+            c = '-'.join([str(x) for x in remove_none(self.idx_1, self.idx_2)])
+            d = '-'.join([str(x) for x in remove_none(
+                        self.atm_1, self.atm_2, self.atm_3, self.atm_4)])
             abcd = remove_none(a, b, c, d)
             self._lbl = '_'.join(abcd)
         return self._lbl
@@ -649,7 +651,7 @@ class MM3(FF):
                             comment = line[COM_POS_START:].strip()
                             self.sub_names.append(comment)
                         parm_cols = line[P_1_START:P_3_END]
-                        parm_cols = list(map(float, parm_cols.split()))
+                        parm_cols = [float(x) for x in parm_cols.split()]
                         self.params.extend((
                                 ParamMM3(atom_labels = atm_lbls,
                                          atom_types = atm_typs,
@@ -697,7 +699,7 @@ class MM3(FF):
                             comment = line[COM_POS_START:].strip()
                             self.sub_names.append(comment)
                         parm_cols = line[P_1_START:P_3_END]
-                        parm_cols = list(map(float, parm_cols.split()))
+                        parm_cols = [float(x) for x in parm_cols.split()]
                         self.params.extend((
                             ParamMM3(atom_labels = atm_lbls,
                                      atom_types = atm_typs,
@@ -733,7 +735,7 @@ class MM3(FF):
                             comment = line[COM_POS_START:].strip()
                             self.sub_names.append(comment)
                         parm_cols = line[P_1_START:P_3_END]
-                        parm_cols = list(map(float, parm_cols.split()))
+                        parm_cols = [float(x) for x in parm_cols.split()]
                         self.params.append(
                             ParamMM3(atom_labels = atm_lbls,
                                      atom_types = atm_typs,
@@ -762,7 +764,7 @@ class MM3(FF):
                             comment = line[COM_POS_START:].strip()
                             self.sub_names.append(comment)
                         parm_cols = line[P_1_START:P_3_END]
-                        parm_cols = list(map(float, parm_cols.split()))
+                        parm_cols = [float(x) for x in parm_cols.split()]
                         self.params.extend((
                             ParamMM3(atom_labels = atm_lbls,
                                      atom_types = atm_typs,
@@ -795,7 +797,7 @@ class MM3(FF):
                         atm_lbls = self.params[-1].atom_labels
                         atm_typs = self.params[-1].atom_types
                         parm_cols = line[P_1_START:P_3_END]
-                        parm_cols = list(map(float, parm_cols.split()))
+                        parm_cols = [float(x) for x in parm_cols.split()]
                         self.params.extend((
                             ParamMM3(atom_labels = atm_lbls,
                                      atom_types = atm_typs,
@@ -838,7 +840,7 @@ class MM3(FF):
                             comment = line[COM_POS_START:].strip()
                             self.sub_names.append(comment)
                         parm_cols = line[P_1_START:P_3_END]
-                        parm_cols = list(map(float, parm_cols.split()))
+                        parm_cols = [float(x) for x in parm_cols.split()]
                         self.params.extend((
                             ParamMM3(atom_labels = atm_lbls,
                                      atom_types = atm_typs,
@@ -865,7 +867,7 @@ class MM3(FF):
                             atm_typs = self.convert_to_types(
                                 atm_lbls, self.atom_types[-1])
                         parm_cols = line[P_1_START:P_3_END]
-                        parm_cols = map(float, parm_cols.split())
+                        parm_cols = [float(x) for x in parm_cols.split()]
                         self.params.extend((
                                 ParamMM3(atom_labels = atm_lbls,
                                          atom_types = atm_typs,
@@ -1284,8 +1286,8 @@ def mass_weight_hessian(hess, atoms, reverse=False):
     for mass in masses:
         changes.extend([1 / np.sqrt(mass)] * 3)
     x, y = hess.shape
-    for i in xrange(0, x):
-        for j in xrange(0, y):
+    for i in range(0, x):
+        for j in range(0, y):
             if reverse:
                 hess[i, j] = \
                     hess[i, j] / changes[i] / changes[j]
@@ -1303,8 +1305,8 @@ def mass_weight_eigenvectors(evecs, atoms, reverse=False):
         if not atom.is_dummy:
             changes.extend([np.sqrt(atom.exact_mass)] * 3)
     x, y = evecs.shape
-    for i in xrange(0, x):
-        for j in xrange(0, y):
+    for i in range(0, x):
+        for j in range(0, y):
             if reverse:
                 evecs[i, j] /= changes[j]
             else:

--- a/q2mm/gradient.py
+++ b/q2mm/gradient.py
@@ -1,8 +1,10 @@
+from __future__ import absolute_import
+from __future__ import division
+
 import copy
 import collections
 import csv
 import glob
-import itertools
 import logging
 import logging.config
 import numpy as np
@@ -10,12 +12,12 @@ import os
 import re
 import sys
 
-import calculate
-import compare
-import constants as co
-import datatypes
-import opt as opt
-import parameters
+import .calculate
+import .compare
+import .constants as co
+import .datatypes
+import .opt as opt
+import .parameters
 
 logger = logging.getLogger(__name__)
 
@@ -243,13 +245,7 @@ class Gradient(opt.Optimizer):
             #                  (ref_data[i].val - self.ff.data[i].val)
             count = 0
             for data_type in data_types:
-
-              
-                if (sys.version_info > (3,0)):
-                    rc_zip = zip(r_dict[typ],c_dict[typ])
-                else:
-                    rc_zip = itertools.izip(r_dict[data_type],c_dict[data_type])
-                for r,c in rc_zip:
+                for r,c in zip(r_dict[typ],c_dict[typ]):
                     resid[count, 0] = r.wht * (r.val - c.val)
                     count += 1
             # logger.log(5, 'RESIDUAL VECTOR:\n{}'.format(resid))
@@ -697,7 +693,7 @@ def return_jacobian(jacob, par_file):
     with open(par_file, 'r') as f:
         logger.log(15, 'READING: {}'.format(par_file))
         f.readline() # Labels.
-        whts = list(map(float, f.readline().split(','))) # Weights.
+        whts = [float(x) for x in f.readline().split(',')] # Weights.
         f.readline() # Reference values.
         f.readline() # Original values.
         # This is only for central differentiation.
@@ -709,12 +705,8 @@ def return_jacobian(jacob, par_file):
                 break
             inc_data = map(float, l1.split(','))
             dec_data = map(float, l2.split(','))
-            if (sys.version_info > (3, 0)):
-                data_zip = zip(inc_data, dec_data)
-            else:
-                data_zip = itertools.izip(inc_data, dec_data)
             for data_ind, (inc_datum, dec_datum) in \
-                    enumerate(data_zip):
+                    enumerate(zip(inc_data, dec_data)):
                 dydp = (inc_datum - dec_datum) / 2
                 jacob[data_ind, ff_ind] = whts[data_ind] * dydp
             ff_ind += 1
@@ -768,11 +760,7 @@ def update_params(params, changes):
                     Unscaled changes to the parameter values.
     """
     try:
-        if (sys.version_info > (3, 0)):
-            zip_params_changes = zip(params, changes)
-        else:
-            zip_params_changes = itertools.izip(params, changes)
-        for param, change in zip_params_changes:
+        for param, change in zip(params, changes):
             param.value += change * param.step
     except datatypes.ParamError as e:
         logger.warning(e.message)

--- a/q2mm/loop.py
+++ b/q2mm/loop.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python
+
+from __future__ import absolute_import
+from __future__ import division
+
 import argparse
 import glob
-import itertools
 import logging
 import logging.config
 import numpy as np
@@ -10,14 +13,14 @@ import random
 import sys
 import re
 
-import calculate
-import compare
-import constants as co
-import datatypes
-import gradient
-import opt
-import parameters
-import simplex
+import .calculate
+import .compare
+import .constants as co
+import .datatypes
+import .gradient
+import .opt
+import .parameters
+import .simplex
 
 logger = logging.getLogger(__name__)
 
@@ -84,10 +87,7 @@ class Loop(object):
         lines_iterator = iter(lines)
         while True:
             try:
-                if (sys.version_info > (3, 0)):
-                    line = next(lines_iterator)
-                else:
-                    line = lines_iterator.next()
+                line = next(lines_iterator)
             except StopIteration:
                 return self.ff
             cols = line.split()
@@ -117,16 +117,10 @@ class Loop(object):
             if cols[0] == 'LOOP':
                 # Read lines that will be looped over.
                 inner_loop_lines = []
-                if (sys.version_info > (3, 0)):
-                    line = next(lines_iterator)
-                else:
-                    line = lines_iterator.next()
+                line = next(lines_iterator)
                 while line.split()[0] != 'END':
                     inner_loop_lines.append(line)
-                    if (sys.version_info > (3, 0)):
-                        line = next(lines_iterator)
-                    else:
-                        line = lines_iterator.next()
+                    line = next(lines_iterator)
                 # Make loop object and populate attributes.
                 loop = Loop()
                 loop.convergence = float(cols[1])

--- a/q2mm/opt.py
+++ b/q2mm/opt.py
@@ -1,9 +1,11 @@
 """
 General code related to all optimization techniques.
 """
+from __future__ import absolute_import
+from __future__ import division
+
 import copy
 import collections
-import itertools
 import logging
 import logging.config
 import numpy as np
@@ -11,11 +13,11 @@ import re
 import textwrap
 import sys
 
-import calculate
-import compare
-import constants as co
-import datatypes
-import parameters
+import .calculate
+import .compare
+import .constants as co
+import .datatypes
+import .parameters
 
 logger = logging.getLogger(__name__)
 
@@ -230,7 +232,7 @@ def extract_ff_by_params(ffs, params):
     cols = [x.mm3_col for x in params]
     keep = []
     for ff in ffs:
-        row, col = map(int, re.split('\[|\]', ff.method)[3].split(','))
+        row, col = [int(x) for x in re.split('\[|\]', ff.method)[3].split(',')]
         if row in rows and col in cols:
             keep.append(ff)
     logger.log(20, 'KEEPING FFS FOR SIMPLEX:\n{}'.format(
@@ -262,9 +264,6 @@ def param_derivs(ff, ffs):
     ffs : list of `datatypes.FF` (or subclass)
           Central differentiated and scored force fields.
     """
-    # Reverting xrange() to range() as range() in python3 is equivalent to
-    # xrange() in python2. I don't expect the extra memory needed for range()
-    # in python2 will be significant here and syntactically this is simpler
     for i in range(0, len(ffs), 2):
         logger.log(1, '>>> ffs[i].score: {}'.format(ffs[i].score))
         ff.params[int(i/2)].d1 = (ffs[i].score - ffs[i+1].score) * 0.5 # 18
@@ -375,11 +374,7 @@ def pretty_param_changes(params, changes, method=None, level=20):
             '--')
         # This calculation of the real parameter step size is also repeated.
         # The things I do for a good looking log.
-        if (sys.version_info > (3, 0)):
-            zip_param_change = zip(params, changes)
-        else:
-            zip_param_change = itertools.izip(params, changes)
-        for param, change in zip_param_change:
+        for param, change in zip(params, changes):
             logger.log(
                 level,
                 '  ' + '{}'.format(param).ljust(34, ' ') +

--- a/q2mm/parameters.py
+++ b/q2mm/parameters.py
@@ -6,15 +6,18 @@ ASSUMES THERE IS NO OVERLAP BETWEEN THE PARAMETERS SELECTED BY THE PARAMETER
 FILE AND BY PTYPES!
 '''
 from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import division
+
 import argparse
 import logging
 import logging.config
 import numpy as np
 import sys
 
-import constants as co
-import datatypes
-import filetypes
+import .constants as co
+import .datatypes
+import .filetypes
 
 logger = logging.getLogger(__name__)
 
@@ -183,7 +186,7 @@ def read_param_file(filename):
                 elif cols[2:]:
                     # Selects all values after 2 as a list, and then
                     # trims to only 2 values.
-                    allowed_range = list(map(float, cols[2:][:2]))
+                    allowed_range = [float(x) for x in cols[2:][:2]]
                 else:
                     allowed_range = None
                 # Add information to the temporary list.
@@ -230,7 +233,7 @@ def main(args):
     '''
     # basestring is deprecated in python3, str is probably safe to use in both
     # but should be tested, for now sys.version_info switch can handle it
-    if (sys.version_info > (3, 0)):
+    if sys.version_info > (3, 0):
         if isinstance(args, str):
             args = args.split()
     else:
@@ -285,11 +288,11 @@ def main(args):
             #             1858: 1.3556
             #            }
             bond_avg = {}
-            for ff_row, values in bond_dic.iteritems():
+            for ff_row, values in bond_dic.items():
                 bond_avg[ff_row] = np.mean(values)
                 print(">> STD {}: {}".format(ff_row,np.std(values)))
             angle_avg = {}
-            for ff_row, values in angle_dic.iteritems():
+            for ff_row, values in angle_dic.items():
                 angle_avg[ff_row] = np.mean(values)
                 print(">> STD {}: {}".format(ff_row,np.std(values)))
             # Update parameter values.

--- a/q2mm/setup_esp.py
+++ b/q2mm/setup_esp.py
@@ -17,13 +17,16 @@ This script helps setup those ESP calculations for Jaguar and
 Gaussian.
 """
 from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import division
+
 import argparse
 import copy
 import logging
 import logging.config
 
-import constants as co
-import filetypes as ft
+import .constants as co
+import .filetypes as ft
 
 logger = logging.getLogger(__name__)
 

--- a/q2mm/simplex.py
+++ b/q2mm/simplex.py
@@ -1,9 +1,11 @@
 """
 Simplex optimization.
 """
+from __future__ import absolute_import
+from __future__ import division
+
 import copy
 import collections
-import itertools
 import logging
 import logging.config
 import numpy as np
@@ -11,12 +13,12 @@ import re
 import sqlite3
 import textwrap
 
-import calculate
-import compare
-import constants as co
-import datatypes
-import opt
-import parameters
+import .calculate
+import .compare
+import .constants as co
+import .datatypes
+import .opt
+import .parameters
 
 logger = logging.getLogger(__name__)
 
@@ -256,7 +258,7 @@ class Simplex(opt.Optimizer):
                     raise opt.OptError(
                         'No difference between force field scores. '
                         'Exiting simplex.')
-            for i in xrange(0, len(last_best_ff.params)):
+            for i in range(0, len(last_best_ff.params)):
                 if self.do_weighted_reflection:
                     inv_val = (
                         sum([x.params[i].value *
@@ -287,7 +289,7 @@ class Simplex(opt.Optimizer):
                 exp_ff = self.ff.__class__()
                 exp_ff.method = 'EXPANSION'
                 exp_ff.params = copy.deepcopy(last_best_ff.params)
-                for i in xrange(0, len(last_best_ff.params)):
+                for i in range(0, len(last_best_ff.params)):
                     exp_ff.params[i].value = (
                         3 * inv_ff.params[i].value -
                         2 * self.new_ffs[-1].params[i].value)
@@ -317,7 +319,7 @@ class Simplex(opt.Optimizer):
                 con_ff = self.ff.__class__()
                 con_ff.method = 'CONTRACTION'
                 con_ff.params = copy.deepcopy(last_best_ff.params)
-                for i in xrange(0, len(last_best_ff.params)):
+                for i in range(0, len(last_best_ff.params)):
                     if ref_ff.score > self.new_ffs[-1].score:
                         con_val = (
                             (inv_ff.params[i].value +
@@ -345,7 +347,7 @@ class Simplex(opt.Optimizer):
                     logger.log(
                         20, '~~ DOING MASSIVE CONTRACTION ~~'.rjust(79, '~'))
                     for ff_num, ff in enumerate(self.new_ffs[1:]):
-                        for i in xrange(0, len(last_best_ff.params)):
+                        for i in range(0, len(last_best_ff.params)):
                             ff.params[i].value = (
                                 (ff.params[i].value +
                                  self.new_ffs[0].params[i].value) / 2)

--- a/screen/merge.py
+++ b/screen/merge.py
@@ -621,7 +621,7 @@ def merge_structures_from_matching_atoms(struct_1, match_1, struct_2, match_2):
                     atom2.index, atom2.atom_type_name))
 
             bond = merge.getBond(atom1, atom2)
-            for k, v in merge_bond.property.iteritems():
+            for k, v in merge_bond.property.items():
                 # Here, bond is the duplicate bond in struct_1 or the new bond.
                 if k not in bond.property or not bond.property[k]:
                     # For i_cs_rca4_1, i_cs_rca4_2, i_cs_torc_a1, etc.
@@ -720,7 +720,7 @@ def add_chirality(structure):
     """
     chirality_dic = analyze.get_chiral_atoms(structure)
     string = '_'
-    for key, value in chirality_dic.iteritems():
+    for key, value in chirality_dic.items():
         string += '{}{}'.format(key, value.lower())
     structure.property['s_m_title'] += string
     structure.property['s_m_entry_name'] += string
@@ -736,7 +736,7 @@ def search_dic_keys(dic, lookup):
     dic : dictionary
     lookup : string
     """
-    for key, value in dic.iteritems():
+    for key, value in dic.items():
         if lookup in key:
             yield value
 

--- a/tools/clean_mae_same_update.py
+++ b/tools/clean_mae_same_update.py
@@ -65,7 +65,7 @@ if __name__ == "__main__":
 
             for bond in structure.bond:
                 # Update 1st.
-                for k, v in CONV_DIC.iteritems():
+                for k, v in CONV_DIC.items():
                     if k in bond.property:
                         bond.property[v] = bond.property[k]
                         del bond.property[k]


### PR DESCRIPTION
- I've gone through the code and edited a lot of places to adopt a cleaner
  style to make the code compatible with python 2 and 3
- Most of these changes are based on suggestions from
  https://portingguide.readthedocs.io/en/latest/index.html
- In a lot of places python2 will now be using lists where iterators were
  used before. This is due to a major shift in python 3 where iterators
  are now a bigger focus. In all likelyhood this won't cause any significant
  loss in performance unless the iterables contain many thousands of objects
- Using the built-in methods which return lists in python 2 and iterators in
  python 3 keeps the codebase smaller, more readable, and avoids external
  dependencies
- Below are explanations for major changes to coding style along with
  explanations of the changes in behavior from python 2 to 3 and preferred
  styles to use in the future to keep the code compatible with both versions
- Keep in mind that python 2 is end-of-life in 2020 and Schrodinger has
  switched to only support python 3 since any release 2018 or later, so
  using python 3 now is encouraged

Iterators no longer have .next(), use next()

- In python 3 the .next() method was removed from iterators
- Instead the next() built-in method should be used, i.e. next(iterator)
- next() built-in was backported to python 2.6+ so this should be fine
- One note is that according to Schrodinger's python API reference, I believe that the structure.StructureReader
  still relies on .next() through their 2018u3 release. In 2018u4 their documentation of this changes to use next()
  so for the time being I have left this to use .next() since the CRC currently only has 2018u3. You can find the reference
  to StructureReader for 2018u3 and 2018u4 at
  http://content.schrodinger.com/Docs/r2018-3/python_api/api/schrodinger.structure.html#schrodinger.structure.StructureReader
  and
  http://content.schrodinger.com/Docs/r2018-4/python_api/api/schrodinger.structure.html#schrodinger.structure.StructureReader

Use absolute imports and explicit relative imports

- In python3 absolute imports are checked first before implicit relative imports
- In python2 this was the other way around, so if your module had a submodule names math, then `import math` would import that submodule rather than the module from the standard library
- Add `from __future__ import absolute_import` to bring this behavior to python2
- Absolute imports used for core python modules
- Submodules imported from q2mm or other python modules should use absolute import syntax or atleast explicit relative syntax
- E.g. `import q2mm.gradient` or `import .gradient` are ok but not `import gradient` when importing q2mm's gradient submodule

Use python3 division to result in float

- In python3, division of two ints results in a float
- In python2, this resulted in an int instead
- Use `from __future__ import division` to bring python3 division behavior to python2
- If you desire the old behavior, use `//` as the division operator to return an int
- I've done some preliminary checks and didn't see any obvious places where the int was needed without explicitly being typed
- If anything breaks, please keep this change in mind if your code uses any division

Changing instances of map() to list comprehension

- In python3 map() now returns an iterator instead of a list
- I've exchanged cases where a list was needed with list comprehensions
- I tried to leave map() in places where an iterator would still work
- In the future use list comprehensions when you need a list, or map
when you need an iterator
- Wrapping map in list (i.e. list(map(func, iterable))) is OK but not
very pythonic

Changing izip() to zip()

- In python3 zip() now generates an iterator where in python2 izip() from itertools was needed to do this.
- Previously I changed these to use zip() if python3 was being used or izip() if python2 was being used
- In favor of readability and removing unnecessary dependencies I've changed all of these to just use zip() regardless of python version
- This is highly unlikely to cause any significant problems with performance

Changing xrange() to range()

- In python3 range() now behave exactly how xrange() did in python2
- Most likely this won't affect performance anywhere, so for readability just using range()

Changing any dict.iter*() to dict.*()

- In python3 dict.iteritems(), dict.iterkeys(), etc. has been removed
- Similarly dict.viewitems(), etc. has also been removed
- Instead dict.items(), etc. now returns a view object
- Views are memory efficient like iterators but are dynamic in that
  changing the dictionary changes what is in the view
- For the most part, when iterating over the keys or values in a dict
  it will work the same as iterating over lists unless the dict object
  is changed

Leaving version switch to deal with basestring

- Basestring has been removed from python3 as all text-type strings
  are now unicode, which was not the case in python2
- Most solutions to this require dependence on `six` or another python
  module for dealing with python2/3 differences in a clean way
- Since most of these compatabilities have been handled without using
  an external dependence then to avoid adding that dependence I'm just
  going to leave the if statements which switch behavior based on
  python version