### PR TITLE
Fixes three small bugs

### DIFF
--- a/q2mm/datatypes.py
+++ b/q2mm/datatypes.py
@@ -97,8 +97,6 @@ class Param(object):
                     "{} doesn't have a default step size and none "
                     "provided!".format(self))
                 raise
-        if self._step == 0.:
-            self._step = 0.1
         if sys.version_info > (3, 0):
             if isinstance(self._step, str):
                 return float(self._step) * self.value
@@ -135,6 +133,26 @@ class Param(object):
                     value,
                     self.allowed_range[0],
                     self.allowed_range[1]))
+
+    def value_at_limits(self):
+        # Checks if the parameter is at the limits of
+        # its allowed range. Should only be run at the
+        # end of an optimization to warn users they should
+        # consider whether this is ok.
+        if self.value == min(self.allowed_range):
+            logger.warning(
+                "{} is equal to its lower limit of {}!\nReconsider "
+                "if you need to adjust limits, initial parameter "
+                "values, or if your reference data is appropriate.".format(
+                    str(self),
+                    self.value))
+        if self.value == max(self.allowed_range):
+            logger.warning(
+                "{} is equal to its upper limit of {}!\nReconsider "
+                "if you need to adjust limits, initial parameter "
+                "values, or if your reference data is appropriate.".format(
+                    str(self),
+                    self.value))
 
 # Need a general index scheme/method/property to compare the equalness of two
 # parameters, rather than having to rely on some expression that compares

--- a/q2mm/gradient.py
+++ b/q2mm/gradient.py
@@ -245,7 +245,7 @@ class Gradient(opt.Optimizer):
             #                  (ref_data[i].val - self.ff.data[i].val)
             count = 0
             for data_type in data_types:
-                for r,c in zip(r_dict[typ],c_dict[typ]):
+                for r,c in zip(r_dict[data_type],c_dict[data_type]):
                     resid[count, 0] = r.wht * (r.val - c.val)
                     count += 1
             # logger.log(5, 'RESIDUAL VECTOR:\n{}'.format(resid))
@@ -763,6 +763,6 @@ def update_params(params, changes):
         for param, change in zip(params, changes):
             param.value += change * param.step
     except datatypes.ParamError as e:
-        logger.warning(e.message)
+        logger.warning(str(e))
         raise
 

--- a/q2mm/loop.py
+++ b/q2mm/loop.py
@@ -82,6 +82,8 @@ class Loop(object):
             mm3_file = os.path.join(self.direc, mm3_file)
             self.ff.export_ff(path=mm3_file)
             logger.log(20, '  -- Wrote best FF to {}'.format(mm3_file))
+        for param in self.ff.params:
+            param.value_at_limits()
         return self.ff
     def run_loop_input(self, lines, score=None):
         lines_iterator = iter(lines)

--- a/q2mm/opt.py
+++ b/q2mm/opt.py
@@ -185,7 +185,7 @@ def differentiate_params(params, central=True):
                 if central:
                     backward_params[i].value = original_value - param.step
             except datatypes.ParamError as e:
-                logger.warning(e.message)
+                logger.warning(str(e))
                 old_step = param.step
                 # New parameter step size modification.
                 # Should prevent problems with parameters trying to go


### PR DESCRIPTION
Fix for printing ParamError exception messages

BaseException.message was deprecated in python 2.5 and has been removed
starting with python3. Exception has __str__ and __repr__ methods implemented
such that you can print the Exception message by calling str() on the
caught exception.

Adds a param check after optimization completes

Adds a small check at the end of the optimization loop to see if any
parameters are at either of its limits and prints a warning to the
user if they are. Also removes resetting the step size for a param
to 0.1 if the step is 0.0. Fixes #51

Fixes a small bug that @jesswahlers found

I made a copy/paste bug here that Jess found and helped me to
resolve. More reason we need to get Q2MM packaged properly and
add some testing to run before pull requests can be merged so that
I don't push bugs to the master repo and ruin everyone's workflow.