### PR TITLE
fixes string formatting compatibility

### DIFF
--- a/q2mm/compare.py
+++ b/q2mm/compare.py
@@ -166,7 +166,7 @@ def compare_data(r_dict, c_dict, output=None, doprint=False):
                     score_typ[c.typ + '-o'] += score
                     num_typ[c.typ + '-o'] += 1
             strings.append('  {:<30}  {:>7.2f}  {:>11.4f}  {:>11.4f}  {:>11.4f}  '\
-                       '{:>5} '.format(
+                       '{!s:>5} '.format(
                         c.lbl, r.wht, r.val, c.val, score, c.ff_row))
     strings.append('-' * 89)
     strings.append('{:<20} {:20.4f}'.format('Total score:', score_tot))


### PR DESCRIPTION
I've fixed this multiple times in my own branches and somehow I never got this merged into master. This should fix the error from @peonor email. It's a python 2/3 compatibility. I believe it has to do with a "None" object which I guess the string formatting can't handle without this little change.