### PR TITLE
basestring changed to str for py3 compatibility

### DIFF
--- a/q2mm/calculate.py
+++ b/q2mm/calculate.py
@@ -1684,7 +1684,7 @@ def flatten(l):
     import collections
     for el in l:
         if isinstance(el, collections.Iterable) and \
-          not isinstance(el, basestring):
+          not isinstance(el, str):
             for sub in flatten(el):
                 yield sub
         else:


### PR DESCRIPTION
Basestring is no longer a class in python3. This all has to do with compatibility of unicode strings vs the old types of strings in python2. In python3 every string is a unicode string now so basestring was dropped as a class.