### PR TITLE
Fix bug min value in Hessian matrix being replaced

### DIFF
--- a/q2mm/calculate.py
+++ b/q2mm/calculate.py
@@ -1798,7 +1798,6 @@ def collect_data(coms, inps, direc='.', sub_names=['OPT'], invert=None):
             evals, evecs = np.linalg.eigh(hess)
             datatypes.replace_minimum(evals, value=invert)
             hess = evecs.dot(np.diag(evals).dot(evecs.T))
-        datatypes.replace_minimum(hess, value=invert)
         low_tri_idx = np.tril_indices_from(hess)
         low_tri = hess[low_tri_idx]
         data.extend([datatypes.Datum(


### PR DESCRIPTION
When the option to use the Jaguar Hessian was specified in
`calculate.py`, the minimum value of the Hessian was being replaced.
This is a bug. In this commit, I remove the line of code that replaces
the minimum value of the Hessian.

To invert the Hessian, the Hessian must first be converted into its
eigenmodes. Then most negative eigenmode should then be replaced. Then
the Hessian should be reformed. This process takes place when `--invert`
is specified IN ADDITION TO the bug mentioned above.

For a full discusion on this issue, please refer to issue #57. Closes
issue #57.